### PR TITLE
Rename pasteDelegate to jsq_pasteDelegate

### DIFF
--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -43,7 +43,7 @@
     self.senderId = kJSQDemoAvatarIdSquires;
     self.senderDisplayName = kJSQDemoAvatarDisplayNameSquires;
     
-    self.inputToolbar.contentView.textView.pasteDelegate = self;
+    self.inputToolbar.contentView.textView.jsq_pasteDelegate = self;
     
     /**
      *  Load up our fake data for the demo

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
@@ -55,7 +55,7 @@
 /**
  *  The object that acts as the paste delegate of the text view.
  */
-@property (weak, nonatomic) id<JSQMessagesComposerTextViewPasteDelegate> pasteDelegate;
+@property (weak, nonatomic) id<JSQMessagesComposerTextViewPasteDelegate> jsq_pasteDelegate;
 
 /**
  *  Determines whether or not the text view contains text after trimming white space 

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -142,7 +142,7 @@
 
 - (void)paste:(id)sender
 {
-    if (!self.pasteDelegate || [self.pasteDelegate composerTextView:self shouldPasteWithSender:sender]) {
+    if (!self.jsq_pasteDelegate || [self.jsq_pasteDelegate composerTextView:self shouldPasteWithSender:sender]) {
         [super paste:sender];
     }
 }


### PR DESCRIPTION
In the iOS 11.0 SDK Apple added UITextPasteConfigurationSupporting
which made pasteDelegate a property on UITextView which
JSQMessagesComposerTextView inherits. This class also defines a
pasteDelegate of type JSQMessagesComposerTextViewPasteDelegate, but
it ends up being an object confirming to the UITextPaste… protocol
that causes an unrecognized selector and crashes.

There are several other fixes available but most seem to agree that
renaming this delegate is the most appropriate solution.

This fixes hakonber/wordfeud-ios#1495.
